### PR TITLE
Add the quality value to each upload

### DIFF
--- a/data/cli-test-references/test_concurrent_quality_uploads.reference
+++ b/data/cli-test-references/test_concurrent_quality_uploads.reference
@@ -1,0 +1,20 @@
+========== TEST test_concurrent_quality_uploads - Concurrent uploads with different quality settings ==========
+
+
+---------- SUBTEST Clear conversion cache ----------
+
+ikup cache remove --all
+Removed {{.*}} cached images
+
+---------- SUBTEST Running many concurrent upload processes ----------
+
+Starting many concurrent uploads with different size limits
+Waiting for all processes to complete
+{{:SKIP_LINES:}}
+---------- SUBTEST Check final quality result ----------
+
+All uploads completed, checking final quality
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}} ({{.*}} seconds ago)  size: {{.*}} bytes quality: 1.000 bytes_ago: {{.*}} uploads_ago: 1

--- a/data/cli-test-references/test_display.reference
+++ b/data/cli-test-references/test_display.reference
@@ -152,7 +152,7 @@ ikup ./.cli-tests-data/wikipedia.png -r 2
 ikup list -v
 [1mID: [[id:.*]][0m = 0x{{.*}} id_space: 24bit subspace_byte: {{.*}} = {{.*}} atime: {{.*}} ({{.*}} seconds ago)
   {"path": "{{.*}}", "mtime": {{.*}}, "cols": 5, "rows": 2}
-  Uploaded to st-256color-{{.*}} at {{.*}} ({{.*}} seconds ago)  size: {{.*}} bytes bytes_ago: {{.*}} uploads_ago: {{.*}}
+  Uploaded to st-256color-{{.*}} at {{.*}} ({{.*}} seconds ago)  size: {{.*}} bytes quality: {{.*}} bytes_ago: {{.*}} uploads_ago: {{.*}}
 [0m[38;2;[[rgb(id)]]m􎻮̅̅􎻮̅̍􎻮̅̎􎻮̅̐􎻮̅̒[0m
 [0m[38;2;[[wr2id]]m􎻮̍̅􎻮̍̍􎻮̍̎􎻮̍̐􎻮̍̒[0m
 --------------------------------------------------------------------------------

--- a/data/cli-test-references/test_force_id.reference
+++ b/data/cli-test-references/test_force_id.reference
@@ -49,7 +49,7 @@ ikup display [[id]]
 ikup list -v
 [1mID: [[id]][0m = 0x00123456 {{.*}}
   {"path": "{{.*}}/tux.png", {{.*}}}
-  Uploaded {{.*}} (0 seconds ago)  size: 11913 bytes bytes_ago: 11913 uploads_ago: 1
+  Uploaded {{.*}} size: 11913 bytes quality: 1.000 bytes_ago: 11913 uploads_ago: 1
 [s[0m[38;2;[[rgb(id)]]m􎻮̅̅􎻮̅̍􎻮̅̎􎻮̅̐[0m[uD
 [0m[38;2;[[rgb(id)]]m􎻮̍̅􎻮̍̍􎻮̍̎􎻮̍̐[0m[4DD
 --------------------------------------------------------------------------------

--- a/data/cli-test-references/test_upload_quality.reference
+++ b/data/cli-test-references/test_upload_quality.reference
@@ -1,0 +1,76 @@
+========== TEST test_upload_quality - Quality optimization with different file size limits ==========
+
+
+---------- SUBTEST Clear conversion cache ----------
+
+ikup cache remove --all
+Removed {{.*}} cached images
+
+---------- SUBTEST Upload with small file size limit ----------
+
+Setting IKUP_FILE_MAX_SIZE=8192 and uploading image
+ikup display ./.cli-tests-data/butterfly.jpg
+{{:SKIP_LINES:}}
+Check list -v that it's uploaded with quality < 1.0
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}}  size: {{.*}} bytes quality: [[quality1:0\.[0-9]+]] bytes_ago: {{.*}} uploads_ago: 1
+{{:ASSERT: 0.001 <= float(quality1) <= 0.01}}
+{{:SKIP_LINES:}}
+---------- SUBTEST Upload with even smaller file size limit ----------
+
+Setting IKUP_FILE_MAX_SIZE=4096 and uploading same image
+ikup display ./.cli-tests-data/butterfly.jpg
+{{:SKIP_LINES:}}
+Check that list -v shows that the quality is the same
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}}  size: {{.*}} bytes quality: [[quality1]] bytes_ago: {{.*}} uploads_ago: 1
+{{:SKIP_LINES:}}
+---------- SUBTEST Upload with slightly larger file size limit ----------
+
+Setting IKUP_FILE_MAX_SIZE=9000 and uploading same image
+ikup display ./.cli-tests-data/butterfly.jpg
+{{:SKIP_LINES:}}
+Check that list -v shows that the quality is the same again
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}}  size: {{.*}} bytes quality: [[quality1]] bytes_ago: {{.*}} uploads_ago: 1
+{{:SKIP_LINES:}}
+---------- SUBTEST Upload with larger file size limit ----------
+
+Setting IKUP_FILE_MAX_SIZE=16384 and uploading same image
+ikup display ./.cli-tests-data/butterfly.jpg
+{{:SKIP_LINES:}}
+Check that list -v shows that the quality is now larger
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}}  size: {{.*}} bytes quality: [[quality2:0\.[0-9]+]] bytes_ago: {{.*}} uploads_ago: 1
+{{:ASSERT: 1.0 > float(quality2) > float(quality1)}}
+{{:SKIP_LINES:}}
+---------- SUBTEST Upload without file size limit ----------
+
+Unsetting IKUP_FILE_MAX_SIZE and uploading same image
+ikup display ./.cli-tests-data/butterfly.jpg
+{{:SKIP_LINES:}}
+Check that list -v shows that the quality is now 1.0
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}}  size: {{.*}} bytes quality: 1.000 bytes_ago: {{.*}} uploads_ago: 1
+{{:SKIP_LINES:}}
+---------- SUBTEST Upload with small file size limit again ----------
+
+Setting IKUP_FILE_MAX_SIZE=8192 again and uploading same image
+ikup display ./.cli-tests-data/butterfly.jpg
+{{:SKIP_LINES:}}
+Check that list -v shows that the quality is still 1.0
+ikup list -v ./.cli-tests-data/butterfly.jpg
+{{.*}}
+{{.*}}
+  Uploaded to {{.*}} at {{.*}}  size: {{.*}} bytes quality: 1.000 bytes_ago: {{.*}} uploads_ago: 1
+{{:SKIP_LINES:}}

--- a/ikup/graphics_terminal.py
+++ b/ikup/graphics_terminal.py
@@ -1,7 +1,7 @@
 import base64
 import copy
 import fcntl
-import io
+import logging
 import os
 import random
 import select
@@ -24,6 +24,8 @@ from ikup.placeholder import (
     ImagePlaceholder,
     ImagePlaceholderMode,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class TtySettingsGuard:
@@ -458,6 +460,7 @@ class GraphicsTerminal:
 
         template = self.get_graphics_command_template()
         # Send the command.
+        logger.debug("Sending command: %s", command)
         command.send(
             self.out_command,
             template=template,

--- a/tests/test_id_manager.py
+++ b/tests/test_id_manager.py
@@ -354,11 +354,11 @@ def test_id_manager_uploads():
             id_space=IDSpace(),
         )
         for term in terminals:
-            assert idman.needs_uploading(id, term)
+            assert idman.needs_uploading_for_testing(id, term)
             assert idman.get_upload_info(id, term) is None
             if random.random() < 0.5:
                 idman.mark_uploaded_for_testing(id, term, size=size)
-                assert not idman.needs_uploading(id, term)
+                assert not idman.needs_uploading_for_testing(id, term)
                 info = idman.get_upload_info(id, term)
                 assert info
                 term_to_infos[term].append(info)
@@ -410,12 +410,12 @@ def test_id_manager_uploads_example():
     # Manually set id1 to be a different image.
     idman.set_id(id1, "1-re")
     # Now id1 needs uploading.
-    assert idman.needs_uploading(id1, "term1")
+    assert idman.needs_uploading_for_testing(id1, "term1")
     # Mark it as uploaded again to term1, but not to term2.
     idman.mark_uploaded_for_testing(id1, "term1", size=100)
     # Now it doesn't need uploading to term1 but still needs uploading to term2.
-    assert not idman.needs_uploading(id1, "term1")
-    assert idman.needs_uploading(id1, "term2")
+    assert not idman.needs_uploading_for_testing(id1, "term1")
+    assert idman.needs_uploading_for_testing(id1, "term2")
     # Check the new info.
     assert idman.get_upload_info(id1, "term1").bytes_ago == 100
     assert idman.get_upload_info(id1, "term1").uploads_ago == 1


### PR DESCRIPTION
This commit adds the quality field to the table of uploads. The quality is currently defines as the are ratio between the optimized image and the original image. Tracking quality is important because we want to reupload images if better quality is allowed.